### PR TITLE
Prevent getting the first item when name is empty

### DIFF
--- a/framework/rbac/DbManager.php
+++ b/framework/rbac/DbManager.php
@@ -214,6 +214,10 @@ class DbManager extends BaseManager
      */
     protected function getItem($name)
     {
+        if (empty($name)) {
+            return null;
+        }
+        
         if (!empty($this->items[$name])) {
             return $this->items[$name];
         }


### PR DESCRIPTION
When an empty string or null value is passed by accident to the DbManager unintentional access might be granted if the user has permission on the first item in the table.
